### PR TITLE
Remove raw conversion to keep special characters

### DIFF
--- a/endent.js
+++ b/endent.js
@@ -7,12 +7,12 @@ module.exports = endent
 const ENDENT_ID = 'twhZNwxI1aFG3r4'
 
 function endent (strings, ...values) {
-  const raw = typeof strings === 'string' ? [strings] : strings.raw
+  strings = [].concat(strings)
 
   let result = ''
 
-  for (let i = 0; i < raw.length; i++) {
-    result += raw[i]
+  for (let i = 0; i < strings.length; i++) {
+    result += strings[i]
 
     if (i < values.length) {
       let value = values[i]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "endent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -109,7 +109,7 @@ test('issue#1', t => {
   const r = endent`
     {
       ${a}: null
-    }    
+    }
   `
   t.equal(r, `{
   "test": null
@@ -129,4 +129,9 @@ test('issue#2', t => {
 x=hello
   world
 bar.`)
+})
+
+test('tab', t => {
+  t.plan(1)
+  t.equal(endent`foo\tbar`, 'foo\tbar')
 })


### PR DESCRIPTION
Currently all special characters are escaped. This comes from the raw conversion at the beginning of the function. Removing this conversion does not break any tests + it fixes my new test with the tab character.