### PR TITLE
[FAILING TESTS] lines with trailing spaces

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -134,3 +134,12 @@ bar.`
 test("tab", () => {
   expect(endent`foo\tbar`).toEqual("foo\tbar");
 });
+
+test("trailing spaces in empty lines when splicing in text with two consecutive newlines", () => {
+  const insertion = "indented 1\n\nindented 2";
+  const output = endent`
+    foo
+      ${insertion}
+  `;
+  expect(output).toEqual("foo\n  indented 1\n\n  indented 2");
+});


### PR DESCRIPTION
I created this PR instead of opening an issue, because I thought it would be easier to describe and understand. So this is not a PR submitted for merging, but a bug report.

When `endent` encounters spliced in text that is indented relative to other text in the template string, it inserts indentation on any newlines that appear in the spliced in text. (Which is great!) However when the spliced in text contains two (or more) consecutive newline characters, this means that the text that `endent` yields contains lines that contain only spaces. As far as I can tell, this is (almost?) never the desired behavior. So I think `endent` should not insert indentation spaces on empty lines.